### PR TITLE
Add block: include

### DIFF
--- a/spec/blocks_spec.cr
+++ b/spec/blocks_spec.cr
@@ -54,6 +54,19 @@ describe Liquid do
     describe Increment do
     end
 
+    describe Include do
+      it "should include a page" do
+        filename = "spec/data/include.html"
+        expr = Include.new "include    \"#{filename}\""
+        expr2 = Include.new "include \"#{filename}\""
+        expr3 = Include.new "include \"#{filename}\"     "
+
+        expr.template_name.should eq filename
+        expr2.template_name.should eq filename
+        expr3.template_name.should eq filename
+      end
+    end
+
     describe Assign do
       it "should assign a value" do
         expr = Assign.new "assign bool = true"

--- a/spec/blocks_spec.cr
+++ b/spec/blocks_spec.cr
@@ -65,6 +65,45 @@ describe Liquid do
         expr2.template_name.should eq filename
         expr3.template_name.should eq filename
       end
+
+      it "should include a page with variable" do
+        template_name = "spec/data/color"
+        filename = "#{template_name}.liquid"
+        varname = File.basename(template_name)
+        varvalue = "red"
+
+        expr = Include.new "include \"#{template_name}\" with \"#{varvalue}\""
+        ctx = Context.new
+
+        expr.accept RenderVisitor.new ctx
+        expr.template_name.should eq filename
+        ctx.get(varname).should eq varvalue
+      end
+
+      it "should include a page with multi variables" do
+        ctx = Context.new
+        template_name = "spec/data/color.liquid"
+        template_vars = {
+          "string" => "\"green\"",
+          "integer" => 20,
+          "float" => 3.0,
+          "bool" => true,
+        }
+
+        parse_text = "include \"#{template_name}\""
+        template_vars.each do |k, v|
+          parse_text += ", #{k}: #{v}"
+        end
+
+        expr = Include.new parse_text
+        expr.accept RenderVisitor.new ctx
+
+        expr.template_name.should eq template_name
+        ctx.get("string").should eq "green"
+        ctx.get("integer").should eq 20
+        ctx.get("float").should eq 3.0
+        ctx.get("bool").should be_true
+      end
     end
 
     describe Assign do

--- a/spec/data/color.liquid
+++ b/spec/data/color.liquid
@@ -1,0 +1,1 @@
+color is {{ color }}

--- a/spec/data/include.html
+++ b/spec/data/include.html
@@ -1,0 +1,1 @@
+<h1>Hello Liquid.cr</h1>

--- a/spec/template_spec.cr
+++ b/spec/template_spec.cr
@@ -5,7 +5,20 @@ include Liquid
 describe Template do
   it "should render raw text" do
     tpl = Parser.parse("raw text")
+    template_path = __DIR__
+    tpl.template_path = template_path
+
     tpl.render(Context.new).should eq "raw text"
+    tpl.template_path.should eq template_path
+  end
+
+  it "should render from file" do
+    filename = "spec/data/include.html"
+    file_path = File.dirname(filename)
+
+    tpl = Parser.parse(File.open(filename))
+    tpl.render(Context.new).should eq File.read(filename)
+    tpl.template_path.should eq file_path
   end
 
   it "should render for loop with range" do

--- a/src/liquid/blocks.cr
+++ b/src/liquid/blocks.cr
@@ -8,6 +8,7 @@ require "./blocks/raw"
 require "./blocks/for"
 require "./blocks/capture"
 require "./blocks/increment"
+require "./blocks/include"
 # require "./blocks/decrement"
 
 include Liquid::Block
@@ -20,5 +21,6 @@ module Liquid
   BlockRegister.register "capture", Capture
   BlockRegister.register "assign", Assign, false
   BlockRegister.register "increment", Increment, false
+  BlockRegister.register "include", Include, false
   #  BlockRegister.register "decrement", Decrement, false
 end

--- a/src/liquid/blocks/include.cr
+++ b/src/liquid/blocks/include.cr
@@ -1,0 +1,23 @@
+require "./block"
+require "../regex"
+
+module Liquid::Block
+  class Include < InlineBlock
+    INCLUDE = /^include(\s+)(?<template_name>#{STRING})/
+
+    @template_name : String
+
+    getter template_name
+
+    def initialize(@template_name)
+    end
+
+    def initialize(str : String)
+      if match = str.strip.match INCLUDE
+        @template_name = match["template_name"].delete("\"")
+      else
+        raise InvalidNode.new "Invalid assignment Node"
+      end
+    end
+  end
+end

--- a/src/liquid/blocks/include.cr
+++ b/src/liquid/blocks/include.cr
@@ -3,18 +3,35 @@ require "../regex"
 
 module Liquid::Block
   class Include < InlineBlock
-    INCLUDE = /^include(\s+)(?<template_name>#{STRING})/
+    INCLUDE = /^include(\s+)(?<template_name>#{STRING})(\s+with\s+(?<value>#{TYPE_OR_VAR}))?/
+    INCLUDE_VARS = /\s*\,\s*(?<varname>#{VAR})\s*\:\s*(?<value>#{TYPE_OR_VAR})/
 
     @template_name : String
+    @template_vars : Hash(String, Expression)
 
-    getter template_name
+    getter template_name, template_vars
 
-    def initialize(@template_name)
+    def initialize(@template_name, @template_vars)
     end
 
     def initialize(str : String)
       if match = str.strip.match INCLUDE
+        @template_vars = {} of String => Expression
         @template_name = match["template_name"].delete("\"")
+        @template_name += ".liquid" if File.extname(@template_name).empty?
+
+        if match["value"]?
+          varname = File.basename(@template_name, File.extname(@template_name))
+          @template_vars[varname] = Expression.new match["value"]
+        elsif groups = str.strip.scan INCLUDE_VARS
+          groups.each do |group|
+            next if groups.empty?
+
+            groups.each do |group|
+              @template_vars[group["varname"]] = Expression.new group["value"]
+            end
+          end
+        end
       else
         raise InvalidNode.new "Invalid assignment Node"
       end

--- a/src/liquid/codegen_visitor.cr
+++ b/src/liquid/codegen_visitor.cr
@@ -58,6 +58,10 @@ module Liquid
                     Liquid::Block::Expression.new("#{escape node.value.var}")))
     end
 
+    def visit(node : Include)
+      to_io %(Liquid::Block::Include.new("#{escape node.template_name}"))
+    end
+
     def visit(node : Capture)
       def_to_io %(Liquid::Block::Capture.new("#{escape node.var_name}"))
       push

--- a/src/liquid/parser.cr
+++ b/src/liquid/parser.cr
@@ -21,6 +21,15 @@ module Liquid
       Template.new internal.root
     end
 
+    def self.parse(file : File)
+      str = file.gets_to_end
+      path = File.dirname(file.path)
+
+      internal = self.new str
+      internal.parse
+      Template.new internal.root, path
+    end
+
     def initialize(@str)
       @root = Root.new
       @nodes << @root

--- a/src/liquid/regex.cr
+++ b/src/liquid/regex.cr
@@ -6,7 +6,7 @@ module Liquid
   STRING      = /"[^"]*"/
   INT         = /-?[1-9][0-9]*/
   FLOAT       = /#{INT}\.[0-9]+/
-  TYPE        = /(?:#{STRING})|(?:#{INT})|(?:#{FLOAT})/
+  TYPE        = /(?:#{STRING})|(?:#{FLOAT})|(?:#{INT})/
   TYPE_OR_VAR = /(?:#{TYPE})|(?:#{VAR})/
   CMP         = /(?:#{TYPE_OR_VAR}) ?(?:#{OPERATOR}) ?(?:#{TYPE_OR_VAR})/
   GCMP        = /(?<left>#{TYPE_OR_VAR}) ?(?<op>#{OPERATOR}) ?(?<right>#{TYPE_OR_VAR})/

--- a/src/liquid/render_visitor.cr
+++ b/src/liquid/render_visitor.cr
@@ -4,6 +4,7 @@ module Liquid
   class RenderVisitor < Visitor
     @data : Context
     @io : IO
+    @template_path : String?
 
     def initialize
       @data = Context.new
@@ -15,6 +16,9 @@ module Liquid
     end
 
     def initialize(@data : Context, @io : IO)
+    end
+
+    def initialize(@data : Context, @io : IO, @template_path : String?)
     end
 
     def output
@@ -125,8 +129,14 @@ module Liquid
     end
 
     def visit(node : Include)
-      template_content = File.read node.template_name
-      template = Template.parse(template_content)
+      filename = if @template_path != nil
+          File.join(@template_path.not_nil!, node.template_name)
+        else
+          node.template_name
+        end
+
+      template_content = File.read filename
+      template = Template.parse template_content
       @io << template.render(@data)
     end
 

--- a/src/liquid/render_visitor.cr
+++ b/src/liquid/render_visitor.cr
@@ -124,6 +124,12 @@ module Liquid
       end
     end
 
+    def visit(node : Include)
+      template_content = File.read node.template_name
+      template = Template.parse(template_content)
+      @io << template.render(@data)
+    end
+
     private def render_with_range(node : For, data : Context)
       i = 0
       visitor = RenderVisitor.new data, @io

--- a/src/liquid/render_visitor.cr
+++ b/src/liquid/render_visitor.cr
@@ -134,7 +134,12 @@ module Liquid
         else
           node.template_name
         end
-      filename += ".liquid" if File.extname(filename).empty?
+
+      if node.template_vars != nil
+        node.template_vars.each do |key, value|
+          @data.set key, value.eval(@data)
+        end
+      end
 
       template_content = File.read filename
       template = Template.parse template_content

--- a/src/liquid/render_visitor.cr
+++ b/src/liquid/render_visitor.cr
@@ -134,6 +134,7 @@ module Liquid
         else
           node.template_name
         end
+      filename += ".liquid" if File.extname(filename).empty?
 
       template_content = File.read filename
       template = Template.parse template_content

--- a/src/liquid/template.cr
+++ b/src/liquid/template.cr
@@ -6,18 +6,27 @@ require "./codegen_visitor"
 module Liquid
   class Template
     getter root
+    property template_path
 
     @root : Block::Root
+    @template_path : String?
 
     def self.parse(str : String) : Template
       Parser.parse(str)
     end
 
+    def self.parse(file : File) : Template
+      Parser.parse(file)
+    end
+
     def initialize(@root : Block::Root)
     end
 
+    def initialize(@root : Block::Root, @template_path : String)
+    end
+
     def render(data, io = IO::Memory.new)
-      visitor = RenderVisitor.new data, io
+      visitor = RenderVisitor.new data, io, @template_path
       visitor.visit @root
       visitor.output
     end


### PR DESCRIPTION
Added include block(tag) 

- [x] only include file
- [x] include `with`
- [x] include with multi variables

for support `include` tag, it must use a new variable named "template_path", then it be added in Template and RenderVisitor.

pls review it, thanks

see: https://help.shopify.com/themes/liquid/tags/theme-tags#include