### PR TITLE
Return io in to_code()

### DIFF
--- a/src/liquid/template.cr
+++ b/src/liquid/template.cr
@@ -46,6 +46,7 @@ EOF
 
       io.puts "#{io_name} << Liquid::Template.new(root).render context"
       io.puts "end"
+      io
     end
   end
 end


### PR DESCRIPTION
Useful when io wasn't passed but was assigned default new object.