### PR TITLE
Support passing custom context when rendering via Kilt

### DIFF
--- a/src/liquid/embed.cr
+++ b/src/liquid/embed.cr
@@ -3,6 +3,10 @@ require "json"
 
 module Liquid
   macro embed(filename, io_name, *args)
-    \{{run "liquid/process", {{filename}}, {{io_name.id.stringify}} }}
+    {% if args.size > 0 %}
+      \{{run "liquid/process", {{filename}}, {{io_name.id.stringify}}, {{args[0].id.stringify}}}}
+    {% else %}
+      \{{run "liquid/process", {{filename}}, {{io_name.id.stringify}}}}
+    {% end %}
   end
 end

--- a/src/liquid/template.cr
+++ b/src/liquid/template.cr
@@ -31,20 +31,23 @@ module Liquid
       visitor.output
     end
 
-    def to_code(io_name : String, io : IO = IO::Memory.new)
+    def to_code(io_name : String, io : IO = IO::Memory.new, context : String? = nil)
       visitor = CodeGenVisitor.new io
       io.puts "begin"
 
-      io.puts <<-EOF
+      unless context
+        context = "context"
+        io.puts <<-EOF
 context = Liquid::Context.new
 \{% for var in @type.instance_vars %}
     context.set \{{var.id.stringify}}, @\{{var.id}}
 \{% end %}
 EOF
+      end
 
       root.accept visitor
 
-      io.puts "#{io_name} << Liquid::Template.new(root).render context"
+      io.puts "#{io_name} << Liquid::Template.new(root).render #{context}"
       io.puts "end"
       io
     end

--- a/src/process.cr
+++ b/src/process.cr
@@ -1,8 +1,8 @@
 require "json"
 require "./liquid"
 
-filename, io = ARGV[0], ARGV[1]
+filename, io, context = ARGV[0], ARGV[1], ARGV[2]?
 raise "Liquid template: #{filename} doesn't exist." unless File.exists?(filename)
 
 tpl = Liquid::Template.parse File.read(filename)
-tpl.to_code io, STDOUT
+tpl.to_code io, STDOUT, context


### PR DESCRIPTION
With this patch, support for rendering via Kilt is complete.

If custom context is not provided, then behavior remains as it
was before - a new context object is automatically created and
object's instance variables are made visible in it.

If custom context is provided, then that context is used.