### PR TITLE
Upgrade to Crystal v0.31.1 and fix block type bug

### DIFF
--- a/spec/comparison_spec.cr
+++ b/spec/comparison_spec.cr
@@ -14,8 +14,8 @@ describe Liquid::BinOperator do
   end
 
   it "should compare Time" do
-    BinOperator.process("<=", Any.new(Time.now), Any.new(Time.now)).should eq Any.new true
-    t = Time.now
+    BinOperator.process("<=", Any.new(Time.utc), Any.new(Time.utc)).should eq Any.new true
+    t = Time.utc
     BinOperator.process("==", Any.new(t), Any.new(t)).should eq Any.new true
   end
 end

--- a/spec/filters_spec.cr
+++ b/spec/filters_spec.cr
@@ -100,10 +100,10 @@ describe Liquid::Filters do
 
   describe Date do
     it "should format the date" do
-      time = Time.new(2016, 2, 15, 10, 20, 30) # => 2016-02-15 10:20:30 UTC
+      time = Time.utc(2016, 2, 15, 10, 20, 30) # => 2016-02-15 10:20:30 UTC
       Date.filter(Any.new(time), Array{Any.new "%a, %b %d, %y"}).should eq "Mon, Feb 15, 16"
       Date.filter(Any.new(time), Array{Any.new "%Y"}).should eq "2016"
-      Date.filter(Any.new("now"), Array{Any.new "%Y-%m-%d %H:%M"}).should eq Time.now.to_s "%Y-%m-%d %H:%M"
+      Date.filter(Any.new("now"), Array{Any.new "%Y-%m-%d %H:%M"}).should eq Time.utc.to_s "%Y-%m-%d %H:%M"
     end
   end
 
@@ -118,7 +118,7 @@ describe Liquid::Filters do
 
   describe DividedBy do
     it "should divide Number's by the appropriate value and not matching 0" do
-      DividedBy.filter(Any.new(10), Array{Any.new 4}).should eq 2
+      DividedBy.filter(Any.new(10), Array{Any.new 4}).should eq 2.5
       DividedBy.filter(Any.new(10), Array{Any.new 4.0}).should eq 2.5
       DividedBy.filter(Any.new(10.0), Array{Any.new 4}).should eq 2.5
       DividedBy.filter(Any.new(10.0), Array{Any.new 4.0}).should eq 2.5

--- a/src/liquid/block_register.cr
+++ b/src/liquid/block_register.cr
@@ -1,9 +1,9 @@
 class Liquid::BlockRegister
-  @@inner = Hash(String, Block).new
+  @@inner = Hash(String, Liquid::Block).new
 
-  def self.register(name : String, block : Block, has_end = true)
+  def self.register(name : String, block : Liquid::Block, has_end = true)
     @@inner[name] = block
-    @@inner["end#{name}"] = EndBlock if has_end
+    @@inner["end#{name}"] = Liquid::Block::EndBlock if has_end
   end
 
   def self.for_name(name : String)

--- a/src/liquid/blocks.cr
+++ b/src/liquid/blocks.cr
@@ -15,15 +15,15 @@ require "./blocks/raw"
 include Liquid::Block
 
 module Liquid
-  BlockRegister.register "if", If
-  BlockRegister.register "elsif", ElsIf, false
-  BlockRegister.register "else", Else, false
-  BlockRegister.register "for", For
-  BlockRegister.register "capture", Capture
-  BlockRegister.register "assign", Assign, false
-  BlockRegister.register "increment", Increment, false
-  BlockRegister.register "decrement", Decrement, false
-  BlockRegister.register "include", Include, false
-  BlockRegister.register "raw", Raw
-  BlockRegister.register "comment", Comment
+  BlockRegister.register "if", Liquid::Block::If
+  BlockRegister.register "elsif", Liquid::Block::ElsIf, false
+  BlockRegister.register "else", Liquid::Block::Else, false
+  BlockRegister.register "for", Liquid::Block::For
+  BlockRegister.register "capture", Liquid::Block::Capture
+  BlockRegister.register "assign", Liquid::Block::Assign, false
+  BlockRegister.register "increment", Liquid::Block::Increment, false
+  BlockRegister.register "decrement", Liquid::Block::Decrement, false
+  BlockRegister.register "include", Liquid::Block::Include, false
+  BlockRegister.register "raw", Liquid::Block::Raw
+  BlockRegister.register "comment", Liquid::Block::Comment
 end

--- a/src/liquid/filters/date.cr
+++ b/src/liquid/filters/date.cr
@@ -40,7 +40,7 @@ module Liquid::Filters
       if (time = data.as_t?)
         Any.new time.to_s format
       elsif (d = data.as_s?) && d == "now"
-        Any.new Time.now.to_s format
+        Any.new Time.utc.to_s format
       else
         data
       end


### PR DESCRIPTION
Error occurred when I make a PR to Kilt. https://github.com/jeromegn/kilt/pull/20

```crystal
In lib/liquid/src/liquid/blocks.cr:27:17
 27 | BlockRegister.register "raw", Raw
                    ^-------
Error: no overload matches 'Liquid::BlockRegister.register' with types String, Raw:Module
Overloads are:
 - Liquid::BlockRegister.register(name : String, block : Block, has_end = true)
The command "crystal spec" exited with 1.
```