### PR TITLE
Fix initialize methods for 1.0.0

### DIFF
--- a/src/liquid/blocks/assign.cr
+++ b/src/liquid/blocks/assign.cr
@@ -14,8 +14,8 @@ module Liquid::Block
     def initialize(@varname, @value)
     end
 
-    def initialize(str : String)
-      if match = str.strip.match ASSIGN
+    def initialize(content : String)
+      if match = content.strip.match ASSIGN
         @varname = match["varname"]
         @value = Expression.new match["value"]
       else

--- a/src/liquid/blocks/block.cr
+++ b/src/liquid/blocks/block.cr
@@ -16,7 +16,7 @@ module Liquid::Block
     @children : Array(Node)
     @children = Array(Node).new
 
-    abstract def initialize(content)
+    abstract def initialize(content : String)
 
     def accept(visitor : Visitor)
       visitor.visit self

--- a/src/liquid/blocks/else.cr
+++ b/src/liquid/blocks/else.cr
@@ -5,7 +5,7 @@ module Liquid::Block
     def initialize
     end
 
-    def initialize(str : String)
+    def initialize(content : String)
     end
   end
 end

--- a/src/liquid/blocks/expression.cr
+++ b/src/liquid/blocks/expression.cr
@@ -13,13 +13,13 @@ module Liquid::Block
     @first : Expression
     @filters : Array(Tuple(Filters::Filter, Array(Expression)?))
 
-    def initialize(str)
-      @raw = str
-      if match = str.match GFILTERED
+    def initialize(content : String)
+      @raw = content
+      if match = content.match GFILTERED
         @first = Expression.new match["first"]
         @filters = Array(Tuple(Filters::Filter, Array(Expression)?)).new
       else
-        raise InvalidExpression.new "Invalid filter use :#{str}"
+        raise InvalidExpression.new "Invalid filter use :#{content}"
       end
     end
   end
@@ -28,11 +28,11 @@ module Liquid::Block
     getter inner
     @inner : Bool
 
-    def initialize(str)
-      if match(str)
-        @inner = str == "true"
+    def initialize(content : String)
+      if match(content)
+        @inner = content == "true"
       else
-        raise Exception.new "Invalid Boolean expression : #{str}"
+        raise Exception.new "Invalid Boolean expression : #{content}"
       end
     end
 
@@ -45,8 +45,8 @@ module Liquid::Block
     getter var
     @var : String
 
-    def initialize(var)
-      @var = var.strip
+    def initialize(content : String)
+      @var = content.strip
       pre_cache
     end
 

--- a/src/liquid/blocks/include.cr
+++ b/src/liquid/blocks/include.cr
@@ -14,8 +14,10 @@ module Liquid::Block
     def initialize(@template_name, @template_vars)
     end
 
-    def initialize(str : String)
-      if match = str.strip.match INCLUDE
+    def initialize(content : String)
+      content = content.strip
+
+      if match = content.match INCLUDE
         @template_vars = {} of String => Expression
         @template_name = match["template_name"].delete("\"")
         @template_name += ".liquid" if File.extname(@template_name).empty?
@@ -23,7 +25,7 @@ module Liquid::Block
         if match["value"]?
           varname = File.basename(@template_name, File.extname(@template_name))
           @template_vars[varname] = Expression.new match["value"]
-        elsif groups = str.strip.scan INCLUDE_VARS
+        elsif groups = content.scan INCLUDE_VARS
           groups.each do |group|
             next if groups.empty?
 

--- a/src/liquid/expressions.cr
+++ b/src/liquid/expressions.cr
@@ -33,8 +33,8 @@ module Liquid
       left.not_nil!
     end
 
-    def initialize(str : String)
-      @inner = case str
+    def initialize(content : String)
+      @inner = case content
                when "and" then AND
                when "or"  then OR
                else


### PR DESCRIPTION
Due to https://github.com/crystal-lang/crystal/pull/9634 with 1.0.0-dev you will get 

```
# In lib/liquid/src/liquid/blocks/block.cr:19:18
# 
#  19 | abstract def initialize(content)
#                    ^---------
# Error: abstract `def Liquid::Block::Node#initialize(content)` must be implemented by Liquid::Block::Assign
```

This PR fixes that and polish a bit the rest of the initializations to use the same arg name and type restriction.