### PR TITLE
Remove JSON serializer dependency.

### DIFF
--- a/spec/blocks_spec.cr
+++ b/spec/blocks_spec.cr
@@ -35,7 +35,7 @@ describe Liquid do
         stmt = For.new "for x in myarray"
         stmt << Expression.new "x"
         ctx = Context.new
-        ctx.set("myarray", ["apple", 12])
+        ctx.set("myarray", Any{"apple", 12})
         node_output(stmt, ctx).should eq "apple12"
       end
     end
@@ -231,7 +231,7 @@ describe Liquid do
         expr4.eval(ctx).should be_true
         expr5.eval(ctx).should be_true
         expr5a.eval(ctx).should be_true
-        expr6.eval(ctx).raw.should be_nil # return value is JSON::Any which is not nil; need to check #raw instead
+        expr6.eval(ctx).raw.should be_nil # return value is Any which is not nil; need to check #raw instead
       end
       # it "should eval an operation with contains keyword" do
       #   expr = Expression.new "myarr contains another"

--- a/spec/filters_spec.cr
+++ b/spec/filters_spec.cr
@@ -92,9 +92,9 @@ describe Liquid::Filters do
 
   describe Compact do
     it "should remove all nil values from array" do
-      a = [nil, true, "other", 1, nil, nil, nil, "wuddup!"].to_json
-      expected = [true, "other", 1, "wuddup!"]
-      Compact.filter(JSON.parse(a)).should eq expected
+      a = Any{nil, true, "other", 1, nil, nil, nil, "wuddup!"}
+      expected = Any{true, "other", 1, "wuddup!"}
+      Compact.filter(a).should eq expected
     end
   end
 
@@ -155,10 +155,10 @@ describe Liquid::Filters do
 
   describe First do
     it "should return first result of an array" do
-      a = [false, 1, "two"].to_json
-      empty = [] of String
-      First.filter(JSON.parse(a)).should eq false
-      First.filter(JSON.parse(empty.to_json)).should eq empty
+      a = Any{false, 1, "two"}
+      empty = Any.new([] of Any)
+      First.filter(a).should eq false
+      First.filter(empty).should eq empty
     end
   end
 
@@ -172,17 +172,17 @@ describe Liquid::Filters do
 
   describe Join do
     it "join (yes)" do
-      n = ["John", "Paul", "George", "Ringo"].to_json
-      Join.filter(JSON.parse(n), [Any.new " and "]).should eq "John and Paul and George and Ringo"
+      n = Any{"John", "Paul", "George", "Ringo"}
+      Join.filter(n, [Any.new " and "]).should eq "John and Paul and George and Ringo"
     end
   end
 
   describe Last do
     it "should return the last item in an array that isn't empty" do
-      a = ["one", "two", "three"].to_json
-      empty = [] of String
-      Last.filter(JSON.parse(a)).should eq "three"
-      Last.filter(JSON.parse(empty.to_json)).should eq empty
+      a = Any{"one", "two", "three"}
+      empty = Any.new([] of Any)
+      Last.filter(a).should eq "three"
+      Last.filter(empty).should eq empty
     end
   end
 
@@ -194,11 +194,11 @@ describe Liquid::Filters do
 
   describe Map do
     it "should return the property of the array of hashes & hash values" do
-      d1 = JSON.parse({"category" => "yoo"}.to_json)
-      d2 = JSON.parse([{"category" => "yoo"}, {"category" => "another"}].to_json)
+      d1 = Any{"category" => "yoo"}
+      d2 = Any{Any{"category" => "yoo"}, Any{"category" => "another"}}
       Map.filter(d1, [Any.new "category"]).should eq "yoo"
-      Map.filter(d2, [Any.new "category"]).should eq ["yoo", "another"]
-      Map.filter(d2, [Any.new "test"]).should eq [{"category" => "yoo"}, {"category" => "another"}]
+      Map.filter(d2, [Any.new "category"]).should eq Any{"yoo", "another"}
+      Map.filter(d2, [Any.new "test"]).should eq Any{Any{"category" => "yoo"}, Any{"category" => "another"}}
     end
   end
 
@@ -280,8 +280,8 @@ describe Liquid::Filters do
 
   describe Reverse do
     it "should reverse an array" do
-      d = [1, 2, 3].to_json
-      Reverse.filter(JSON.parse(d)).should eq [3, 2, 1]
+      d = Any{1, 2, 3}
+      Reverse.filter(d).should eq [3, 2, 1]
     end
   end
 
@@ -301,13 +301,13 @@ describe Liquid::Filters do
 
   describe Size do
     it "returns the size of a string, array or hash or return 0" do
-      arr = [1, 2, 3, "4"]
-      hash = {"example" => "hash", :blah => "wut"}
+      arr = Any{1, 2, 3, "4"}
+      hash = Any{"example" => "hash", :blah => "wut"}
 
       Size.filter(Any.new(10)).should eq 0
       Size.filter(Any.new("example")).should eq 7
-      Size.filter(JSON.parse(arr.to_json)).should eq 4
-      Size.filter(JSON.parse(hash.to_json)).should eq 2
+      Size.filter(arr).should eq 4
+      Size.filter(hash).should eq 2
     end
   end
 

--- a/spec/liquid_spec.cr
+++ b/spec/liquid_spec.cr
@@ -3,7 +3,7 @@ require "./spec_helper"
 describe Liquid do
   describe Context do
     it "should allow to add hash to context" do
-      hash = {"test" => "truc"}
+      hash = Any{"test" => "truc"}
       ctx = Context.new
       ctx.set "val", hash
       ctx.get("val").should eq hash
@@ -11,27 +11,27 @@ describe Liquid do
 
     it "should add array to context" do
       ctx = Context.new
-      ctx.set "val", ["str", 12]
-      ctx["val"].should eq ["str", 12]
+      ctx.set "val", Any{"str", 12}
+      ctx["val"].should eq Any{"str", 12}
     end
 
     it "should add hash to context" do
       ctx = Context.new
-      ctx.set "hash", {"some" => "thing", "another" => 12}
-      ctx["hash"].should eq({"some" => "thing", "another" => 12})
+      ctx.set "hash", Any{"some" => "thing", "another" => 12}
+      ctx["hash"].should eq(Any{"some" => "thing", "another" => 12})
       ctx["hash.some"].should eq "thing"
       ctx["hash.another"].should eq 12
     end
 
     it "should add hash of hash to context" do
       ctx = Context.new
-      ctx.set "hash", {"sub" => {"val" => true, "or" => "false"}}
+      ctx.set "hash", Any{"sub" => Any{"val" => true, "or" => "false"}}
       ctx["hash.sub.val"].should be_true
     end
 
     it "should add array of hash to context" do
       ctx = Context.new
-      ctx.set "arr", [{"some" => true, "egg" => 1, "foo" => "bar"}]
+      ctx.set "arr", Any{Any{"some" => true, "egg" => 1, "foo" => "bar"}}
       ctx["arr"][0]["some"].should be_true
       ctx["arr"][0]["foo"].should eq "bar"
     end
@@ -46,7 +46,7 @@ describe Liquid do
       ctx = Context.new(strict: true)
       expect_raises(KeyError) { ctx.get("missing") }
       expect_raises(KeyError) { ctx.get("obj.missing") }
-      ctx["obj"] = {something: "something"}
+      ctx["obj"] = Any{"something" => "something"}
       expect_raises(KeyError) { ctx.get("obj.missing") }
     end
 

--- a/src/liquid/any.cr
+++ b/src/liquid/any.cr
@@ -1,51 +1,275 @@
-require "json"
-
-struct JSON::Any
-  def initialize(raw : Int32)
-    @raw = raw.to_i64
-  end
-
-  def initialize(raw : Float32)
-    @raw = raw.to_f64
-  end
-
-  def initialize(raw : Time)
-    @raw = raw.to_json
-  end
-
-  def as_t?
-    begin
-      as_t
-    rescue
-      nil
-    end
-  end
-
-  def as_t
-    Time.from_json(@raw.as(String))
-  end
-end
-
 module Liquid
-  alias Any = JSON::Any
+  struct Any
+    alias Type = Nil | Bool | Int32 | Int64 | Float32 | Float64 | String | Time | Array(Any) | Hash(String, Any)
 
-  struct AnyHash
-    getter raw
+    # Returns the raw underlying value.
+    getter raw : Type
 
     def initialize
-      @raw = Hash(String, JSON::Type).new
+      @raw = nil
     end
 
-    {% for x in %w(String Int64 Bool Float64) %}
-    def []=(key : String, value : {{x.id}})
-      @raw[key] = value.as(JSON::Type)
-    end
-    {% end %}
-
-    def []=(key : String, value : Array)
+    def initialize(@raw : Type)
     end
 
-    def []=(key : String, value : Hash)
+    def <<(value : Type) : Array(Any)
+      init_raw_to_array_if_nil << Any.new(value)
     end
+
+    def <<(value : Any) : Array(Any)
+      init_raw_to_array_if_nil << value
+    end
+
+    # Assumes the underlying value is an `Array` or `Hash` and returns its size.
+    # Raises if the underlying value is not an `Array` or `Hash`.
+    def size : Int
+      case object = @raw
+      when Array
+        object.size
+      when Hash
+        object.size
+      else
+        raise "Expected Array or Hash for #size, not #{object.class}"
+      end
+    end
+
+    # Assumes the underlying value is an `Array` and returns the element
+    # at the given index.
+    # Raises if the underlying value is not an `Array`.
+    def [](index : Int) : Any
+      case object = @raw
+      when Array
+        object[index]
+      else
+        raise "Expected Array for #[](index : Int), not #{object.class}"
+      end
+    end
+
+    # Assumes the underlying value is an `Array` and returns the element
+    # at the given index, or `nil` if out of bounds.
+    # Raises if the underlying value is not an `Array`.
+    def []?(index : Int) : Any?
+      case object = @raw
+      when Array
+        object[index]?
+      else
+        raise "Expected Array for #[]?(index : Int), not #{object.class}"
+      end
+    end
+
+    # Assumes the underlying value is a `Hash` and returns the element
+    # with the given key.
+    # Raises if the underlying value is not a `Hash`.
+    def [](key : String) : Any
+      case object = @raw
+      when Hash
+        object[key]
+      else
+        raise "Expected Hash for #[](key : String), not #{object.class}"
+      end
+    end
+
+    # Assumes the underlying value is a `Hash` and returns the element
+    # with the given key, or `nil` if the key is not present.
+    # Raises if the underlying value is not a `Hash`.
+    def []?(key : String) : Any?
+      case object = @raw
+      when Hash
+        object[key]?
+      else
+        raise "Expected Hash for #[]?(key : String), not #{object.class}"
+      end
+    end
+
+    def []=(key : String | Symbol, value : Type) : Type
+      init_raw_to_hash_if_nil[key.to_s] = Any.new(value)
+      value
+    end
+
+    def []=(key : String | Symbol, value : Any) : Any
+      init_raw_to_hash_if_nil[key.to_s] = value
+    end
+
+    private def init_raw_to_hash_if_nil : Hash(String, Any)
+      if @raw.nil?
+        @raw = Hash(String, Any).new
+      else
+        as_h
+      end
+    end
+
+    private def init_raw_to_array_if_nil : Array(Any)
+      if @raw.nil?
+        @raw = Array(Any).new
+      else
+        as_a
+      end
+    end
+
+    # Traverses the depth of a structure and returns the value.
+    # Returns `nil` if not found.
+    def dig?(index_or_key : String | Int, *subkeys) : Any?
+      self[index_or_key]?.try &.dig?(*subkeys)
+    end
+
+    # :nodoc:
+    def dig?(index_or_key : String | Int) : Any?
+      case @raw
+      when Hash, Array
+        self[index_or_key]?
+      else
+        nil
+      end
+    end
+
+    # Traverses the depth of a structure and returns the value, otherwise raises.
+    def dig(index_or_key : String | Int, *subkeys) : Any
+      self[index_or_key].dig(*subkeys)
+    end
+
+    # :nodoc:
+    def dig(index_or_key : String | Int) : Any
+      self[index_or_key]
+    end
+
+    # Checks that the underlying value is `Nil`, and returns `nil`.
+    # Raises otherwise.
+    def as_nil : Nil
+      @raw.as(Nil)
+    end
+
+    # Checks that the underlying value is `Bool`, and returns its value.
+    # Raises otherwise.
+    def as_bool : Bool
+      @raw.as(Bool)
+    end
+
+    # Checks that the underlying value is `Bool`, and returns its value.
+    # Returns `nil` otherwise.
+    def as_bool? : Bool?
+      as_bool if @raw.is_a?(Bool)
+    end
+
+    # Checks that the underlying value is `Int`, and returns its value as an `Int32`.
+    # Raises otherwise.
+    def as_i : Int32
+      @raw.as(Int).to_i
+    end
+
+    # Checks that the underlying value is `Int`, and returns its value as an `Int32`.
+    # Returns `nil` otherwise.
+    def as_i? : Int32?
+      as_i if @raw.is_a?(Int)
+    end
+
+    # Checks that the underlying value is `Int`, and returns its value as an `Int64`.
+    # Raises otherwise.
+    def as_i64 : Int64
+      @raw.as(Int).to_i64
+    end
+
+    # Checks that the underlying value is `Int`, and returns its value as an `Int64`.
+    # Returns `nil` otherwise.
+    def as_i64? : Int64?
+      as_i64 if @raw.is_a?(Int64)
+    end
+
+    # Checks that the underlying value is `Float`, and returns its value as an `Float64`.
+    # Raises otherwise.
+    def as_f : Float64
+      @raw.as(Float64)
+    end
+
+    # Checks that the underlying value is `Float`, and returns its value as an `Float64`.
+    # Returns `nil` otherwise.
+    def as_f? : Float64?
+      @raw.as?(Float64)
+    end
+
+    # Checks that the underlying value is `Float`, and returns its value as an `Float32`.
+    # Raises otherwise.
+    def as_f32 : Float32
+      @raw.as(Float).to_f32
+    end
+
+    # Checks that the underlying value is `Float`, and returns its value as an `Float32`.
+    # Returns `nil` otherwise.
+    def as_f32? : Float32?
+      as_f32 if @raw.is_a?(Float)
+    end
+
+    # Checks that the underlying value is `String`, and returns its value.
+    # Raises otherwise.
+    def as_s : String
+      @raw.as(String)
+    end
+
+    # Checks that the underlying value is `String`, and returns its value.
+    # Returns `nil` otherwise.
+    def as_s? : String?
+      @raw.as?(String)
+    end
+
+    # Checks that the underlying value is `Time`, and returns its value.
+    # Raises otherwise.
+    def as_t : Time
+      @raw.as(Time)
+    end
+
+    # Checks that the underlying value is `Time`, and returns its value.
+    # Returns `nil` otherwise.
+    def as_t? : Time?
+      @raw.as?(Time)
+    end
+
+    # Checks that the underlying value is `Array`, and returns its value.
+    # Raises otherwise.
+    def as_a : Array(Any)
+      @raw.as(Array)
+    end
+
+    # Checks that the underlying value is `Array`, and returns its value.
+    # Returns `nil` otherwise.
+    def as_a? : Array(Any)?
+      as_a if @raw.is_a?(Array)
+    end
+
+    # Checks that the underlying value is `Hash`, and returns its value.
+    # Raises otherwise.
+    def as_h : Hash(String, Any)
+      @raw.as(Hash)
+    end
+
+    # Checks that the underlying value is `Hash`, and returns its value.
+    # Returns `nil` otherwise.
+    def as_h? : Hash(String, Any)?
+      as_h if @raw.is_a?(Hash)
+    end
+
+    def inspect(io : IO) : Nil
+      @raw.inspect(io)
+    end
+
+    def to_s(io : IO) : Nil
+      @raw.to_s(io)
+    end
+
+    # :nodoc:
+    def pretty_print(pp)
+      @raw.pretty_print(pp)
+    end
+
+    # Returns `true` if both `self` and *other*'s raw object are equal.
+    def ==(other : Any)
+      raw == other.raw
+    end
+
+    # Returns `true` if the raw object is equal to *other*.
+    def ==(other)
+      raw == other
+    end
+
+    # See `Object#hash(hasher)`
+    def_hash raw
   end
 end

--- a/src/liquid/embed.cr
+++ b/src/liquid/embed.cr
@@ -1,5 +1,4 @@
 require "./context"
-require "json"
 
 module Liquid
   macro embed(filename, io_name, *args)

--- a/src/liquid/filters/arg_test.cr
+++ b/src/liquid/filters/arg_test.cr
@@ -1,15 +1,14 @@
-require "json"
 require "./base"
 
 module Liquid::Filters
   class ArgTest
     extend Filter
 
-    def self.filter(data : JSON::Any, args : Array(JSON::Any)? = nil) : JSON::Any
+    def self.filter(data : Any, args : Array(Any)? = nil) : Any
       if (a = args)
-        JSON::Any.new(a.map(&.to_s).join(", "))
+        Any.new(a.map(&.to_s).join(", "))
       else
-        JSON::Any.new(nil)
+        Any.new(nil)
       end
     end
   end

--- a/src/liquid/filters/compact.cr
+++ b/src/liquid/filters/compact.cr
@@ -1,4 +1,3 @@
-require "json"
 require "./base"
 
 module Liquid::Filters
@@ -6,9 +5,8 @@ module Liquid::Filters
     extend Filter
 
     def self.filter(data : Any, args : Array(Any)? = nil) : Any
-      if (d = data.as_a?)
-        result = d.reject &.raw.nil?
-        JSON.parse(result.to_json)
+      if d = data.as_a?
+        Any.new(d.reject(&.raw.nil?))
       else
         data
       end

--- a/src/liquid/filters/map.cr
+++ b/src/liquid/filters/map.cr
@@ -1,4 +1,3 @@
-require "json"
 require "./base"
 
 module Liquid::Filters
@@ -19,7 +18,7 @@ module Liquid::Filters
         if result.empty?
           data
         else
-          JSON.parse(result.to_json)
+          Any.new(result)
         end
       elsif (raw = data.raw) && raw.is_a?(Hash) && (first = args.first?)
         raw[first.as_s]

--- a/src/liquid/filters/split.cr
+++ b/src/liquid/filters/split.cr
@@ -26,7 +26,7 @@ module Liquid::Filters
     def self.filter(data : Any, args : Array(Any)? = nil) : Any
       if (raw = data.raw) && raw.responds_to?(:split) &&
          args && (fa = args.first?) && (arg = fa.as_s?)
-        JSON.parse raw.split(arg).to_json
+        Any.new(raw.split(arg).map { |s| Any.new(s) })
       else
         data
       end

--- a/src/liquid/render_visitor.cr
+++ b/src/liquid/render_visitor.cr
@@ -220,7 +220,7 @@ module Liquid
         i = 0
         stop = hash.keys.size
         hash.each do |k, v|
-          val = [k, v]
+          val = [Any.new(k), v]
           data.set node.loop_var, val
           data.set "loop.index", i + 1
           data.set "loop.index0", i

--- a/src/process.cr
+++ b/src/process.cr
@@ -1,4 +1,3 @@
-require "json"
 require "./liquid"
 
 filename, io, context = ARGV[0], ARGV[1], ARGV[2]?


### PR DESCRIPTION
`Liquid::Any` is a alias to `JSON::Any`, but in order to implement `Liquid::Drop`
the `Drop` must be part of the `Any::Type` union, so `JSON::Any` can't be used anymore.

While "creating" the proper `Liquid::Any` class I noticed things breaking due to code
that was serializing then deserializing data when setting a context variable, since `Any`
isn't `JSON::Any` anymore and serializing/deserialize data is very slow I fixed this as
well, but at the price of flexibility.

i.e.
```Crystal
ctx = Context{"foo" => ["bar"]}

ctx = Context.new
json = ["bar"].to_json
ctx["foo"] = JSON.parse(json)

ctx = Context{"foo" => Any{"bar"}}
```

To try to be backwards compatible I added few deprecated methods:
- `Context#[]=(String, Array(String))`
- `Context#[]=(String, Hash(String, String))`

Of course this doesn't cover everything that could be accepted with the JSON serialize/deserialize
approach, but I tried 😁.

Despite of this change be required for a `Liquid::Drop` implementation, IMO it's better to remove this
JSON hack from code anyway.