### PR TITLE
Move "include Liquid" to spec_helper, so all tests can be run individually.

### DIFF
--- a/spec/comparison_spec.cr
+++ b/spec/comparison_spec.cr
@@ -1,6 +1,6 @@
 require "./spec_helper"
 
-describe Liquid::BinOperator do
+describe BinOperator do
   it "should compare Boolean" do
     BinOperator.process("==", Any.new(true), Any.new(true)).should eq Any.new true
     BinOperator.process("==", Any.new(false), Any.new(false)).should eq Any.new true

--- a/spec/filters_spec.cr
+++ b/spec/filters_spec.cr
@@ -1,9 +1,8 @@
 require "./spec_helper"
 
-include Liquid
 include Liquid::Filters
 
-describe Liquid::Filters do
+describe Filters do
   describe FilterRegister do
     it "should have registered default filters" do
       FilterRegister.get("abs").should eq Abs

--- a/spec/parser_spec.cr
+++ b/spec/parser_spec.cr
@@ -1,8 +1,6 @@
 require "./spec_helper"
 
-include Liquid
-
-describe Liquid::Parser do
+describe Parser do
   it "parses raw text" do
     txt = "raw text"
     template = Parser.parse txt

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,6 +1,8 @@
 require "spec"
 require "../src/liquid"
 
+include Liquid
+
 def node_output(node : Node, ctx : Context)
   v = RenderVisitor.new ctx, IO::Memory.new
   node.accept v

--- a/spec/template_spec.cr
+++ b/spec/template_spec.cr
@@ -1,7 +1,5 @@
 require "./spec_helper"
 
-include Liquid
-
 describe Template do
   it "should render raw text" do
     tpl = Parser.parse("raw text")


### PR DESCRIPTION
Some tests need the `include Liquid` but didn't have it explicitly, it worked just due to the order the files were required when doing `crystal spec`, since some specs have the include call, but it would fail when trying to run some specs individually.