### PR TITLE
Optimizations

### DIFF
--- a/src/liquid/context.cr
+++ b/src/liquid/context.cr
@@ -67,7 +67,7 @@ module Liquid
           (i + 1...segments.size).each do |j|
             str = segments[j]
             segments[j] = ""
-            segments[i] = [segments[i], str].join(".")
+            segments[i] = "#{segments[i]}.#{str}"
             break if str.includes?("]") # found the closing bracket
           end
         end


### PR DESCRIPTION
Fixes #40

Rendering was slow because in many places a regex was dynamically created by using interpolation. When you do that, a new Regex is created each time. Doing that in a loop makes things really slow.

This PR moves those dynamic regexes into constants.

Here's the benchmark I used:

```crystal
require "benchmark"
require "./src/liquid"

def any(v)
  Liquid::Any.new(v)
end

template = <<-LIQUID
{{ order.uid }}
{{ order.total }}
{{ order.display_total }}
{% for item in order.line_items_collection %}
{{ item.offer_uid }}
{{ item.name }}
{{ item.price }}
{{ item.display_price }}
{{ item.qnt }}
{{ item.url }}
{{ item.main_image_url }}
{{ item.old_price }}
{{ item.display_old_price }}
{% if item.available %}available{% else %}unavailable{% endif %}
{{ item.description }}
{% endfor %}
LIQUID

order = Liquid::Any.new({
  "account"               => any({"id" => any(1)}),
  "visitor"               => any({"id" => any(100)}),
  "uid"                   => any("order-123"),
  "total"                 => any(1000.0),
  "display_total"         => any("$1000"),
  "line_items_collection" => any([
    any({
      "offer_uid"     => any("o-123"),
      "qnt"           => any(1.0),
      "price"         => any("50.0"),
      "display_price" => any("$50"),
    }),
    any({
      "offer_uid"      => any("o-456"),
      "qnt"            => any(2),
      "price"          => any(25),
      "name"           => any("Offer 123"),
      "display_price"  => any("$25"),
      "url"            => any("https://example.net/products/o-456"),
      "main_image_url" => any("https://example.net/images/o-456.jpg"),
      "description"    => any("A multiline\ndescription."),
    }),
  ]),
})

tpl = Liquid::Template.parse(template)
ctx = Liquid::Context.new
ctx.set("order", order)

Benchmark.ips do |x|
  x.report("parse & render") {
    ctx = Liquid::Context.new
    ctx.set("order", order)
    Liquid::Template.parse(template).render(ctx)
  }
  x.report("render") { tpl.render(ctx) }
end
```

Output before this PR:

```
parse & render 544.86  (  1.84ms) (± 0.65%)  389kB/op   2.05× slower
        render   1.12k (893.29µs) (± 1.15%)  202kB/op        fastest
```

Output with this PR:

```
parse & render  20.29k ( 49.28µs) (± 0.47%)  51.4kB/op   1.52× slower
        render  30.77k ( 32.50µs) (± 0.38%)  23.7kB/op        fastest
```

So about 37/27 times faster than before, respectively.

We can now tell the user complaining that Crystal here was 2.5 times slower than Ruby that Crystal is now 15 times faster than Ruby.

By the way, I created those "INTERNED_..." constants, but it looks like those regexes are exactly the same as the "interned" ones 🤔 (I don't know why "intern" is used here)